### PR TITLE
Allow quick searching via the command line to use the whole search term.

### DIFF
--- a/BagSync.lua
+++ b/BagSync.lua
@@ -226,7 +226,7 @@ function BagSync:PLAYER_LOGIN()
 				--do an item search
 				if BagSync_SearchFrame then
 					if not BagSync_SearchFrame:IsVisible() then BagSync_SearchFrame:Show() end
-					BagSync_SearchFrame.SEARCHBTN:SetText(c:lower())
+					BagSync_SearchFrame.SEARCHBTN:SetText(msg)
 					BagSync_SearchFrame:DoSearch()
 				end
 				return true


### PR DESCRIPTION
I mentioned this on WoWInterface, but perhaps I would have better luck here. If you type in something like "/bgs Embersilk Cloth", it will open up a BagSync window with just "Embersilk" in the search box. That doesn't make much sense; if what you typed was not a valid slash command, it should use the whole message and not the first word.
