### PR TITLE
Fixes searching for items that are only present in the guild bank

### DIFF
--- a/BagSync_Search.lua
+++ b/BagSync_Search.lua
@@ -245,10 +245,10 @@ function bgSearch:DoSearch()
 					local guildN = v.guild or nil
 				
 					--check the guild bank if the character is in a guild
-					if BagSyncGUILD_DB and guildN and BagSyncGUILD_DB[guildN] then
+					if BagSyncGUILD_DB and guildN and BagSyncGUILD_DB[currentRealm][guildN] then
 						--check to see if this guild has already been done through this run (so we don't do it multiple times)
 						if not previousGuilds[guildN] then
-							for q, r in pairs(BagSyncGUILD_DB[guildN]) do
+							for q, r in pairs(BagSyncGUILD_DB[currentRealm][guildN]) do
 								local dblink, dbcount = strsplit(',', r)
 								if dblink then
 									local dName, dItemLink, dRarity = GetItemInfo(dblink)


### PR DESCRIPTION
Reverts a change that looks like a mistake in cd30c2b:
https://github.com/Xruptor/BagSync/commit/cd30c2b13fd94cf788cab7f54ce5879af75cf8d6#L3L245

In the current state, if you search for an item that is only present in a guild bank, it will not display on the list.
