### PR TITLE
Use the built-in HandleModifiedItemClick

### DIFF
--- a/BagSync_Search.lua
+++ b/BagSync_Search.lua
@@ -128,14 +128,15 @@ function bgSearch:LoadSlider()
 			row:SetScript("OnLeave", OnLeave)
 			row:SetScript("OnClick", function(self)
 				if self.link then
-					if IsShiftKeyDown() then
+					if HandleModifiedItemClick(self.link) then
+						return
+					end
+					if IsModifiedClick("CHATLINK") then
 						local editBox = ChatEdit_ChooseBoxForSend()
 						if editBox then
 							editBox:Insert(self.link)
 							ChatFrame_OpenChat(editBox:GetText())
 						end
-					elseif IsControlKeyDown() then
-						DressUpItemLink(self.link)
 					end
 				end
 			end)


### PR DESCRIPTION
This uses a Blizzard function to take care of modified clicks on items in the search results. This not only makes linking and dress-ups correspond to their in-game hotkey, but also allows the user to shift+click in other situations, like adding to the AH or trade skill search.

I left a bit of code in as before, so that if you don't have an edit box open, it will still open one with the item.
