### PR TITLE
Ignore Garrision Hearthstone

### DIFF
--- a/BagSync.lua
+++ b/BagSync.lua
@@ -864,7 +864,7 @@ local function AddItemToTooltip(frame, link) --workaround
 	end
 	
 	--ignore the hearthstone and blacklisted items
-	if itemLink and tonumber(itemLink) and (tonumber(itemLink) == 6948 or BS_BL[tonumber(itemLink)]) then
+	if itemLink and tonumber(itemLink) and (tonumber(itemLink) == 6948 or tonumber(itemLink) == 110560 or BS_BL[tonumber(itemLink)]) then
 		frame:Show()
 		return
 	end


### PR DESCRIPTION
The Garrison Hearthstone is equally useless to track as the default Hearthstone.