### PR TITLE
Fix leaked global variables

### DIFF
--- a/BagSync.lua
+++ b/BagSync.lua
@@ -331,7 +331,7 @@ local function ScanVoidBank()
 		
 		for tab = 1, numTabs do
 			for i = 1, 80 do
-				itemID, textureName, locked, recentDeposit, isFiltered = GetVoidItemInfo(tab, i)
+				local itemID, textureName, locked, recentDeposit, isFiltered = GetVoidItemInfo(tab, i)
 				if (itemID) then
 					index = index + 1
 					slotItems[index] = itemID and tostring(itemID) or nil
@@ -846,7 +846,7 @@ local function AddItemToTooltip(frame, link) --workaround
 					end
 				end
 			end
-			_, link = GetItemInfo(newItemId) -- replace original link with our found link
+			link = select(2, GetItemInfo(newItemId)) -- replace original link with our found link
 		end	
 	end
 	

--- a/BagSync_Search.lua
+++ b/BagSync_Search.lua
@@ -42,7 +42,7 @@ ItemSearch:RegisterTypedSearch{
 		
 		for i = 1, tooltipScanner:NumLines() do
 			local text =  _G[tooltipScanner:GetName() .. 'TextLeft' .. i]:GetText():lower()
-			textChk = string.find(text, pattern)
+			local textChk = string.find(text, pattern)
 
 			if textChk and tostring(text):find(search) then
 				result = true


### PR DESCRIPTION
Leaking global variables can lead to taint in the default UI, especially if they are common variable names like _ or itemID.