### PR TITLE
FIX: GetAutoCompleteRealms() returning nothing

### DIFF
--- a/BagSync.lua
+++ b/BagSync.lua
@@ -1125,7 +1125,9 @@ function BagSync:PLAYER_LOGIN()
 	playerClass = select(2, UnitClass("player"))
 	playerFaction = UnitFactionGroup("player")
 
-	for k, v in pairs(GetAutoCompleteRealms()) do	
+	local autoCompleteRealms = GetAutoCompleteRealms() or { currentRealm }
+
+	for k, v in pairs(autoCompleteRealms) do
 		if v ~= currentRealm then
 			crossRealmNames[v] = true
 		end


### PR DESCRIPTION
Added a catch for GetAutoCompleteRealms() returning an empty result which caused the addon to fail with the following error:

BagSync\BagSync-v8.7.lua:1128: bad argument #1 to 'pairs' (table expected, got no value)
[C]: in function `pairs'
BagSync\BagSync-v8.7.lua:1128: in function `?'
BagSync\BagSync-v8.7.lua:94: in function <BagSync\BagSync.lua:92>

Locals:
(*temporary) = "table expected, got no value"
 = <function> defined =[C]:-1