### PR TITLE
FIX: GetInboxItem() change in 7.0.3

### DIFF
--- a/BagSync.lua
+++ b/BagSync.lua
@@ -415,7 +415,7 @@ local function ScanMailbox()
 	if (numInbox > 0) then
 		for mailIndex = 1, numInbox do
 			for i=1, ATTACHMENTS_MAX_RECEIVE do
-				local name, itemTexture, count, quality, canUse = GetInboxItem(mailIndex, i)
+				local name, itemID, itemTexture, count, quality, canUse = GetInboxItem(mailIndex, i)
 				local link = GetInboxItemLink(mailIndex, i)
 				
 				if name and link and ToShortLink(link) then


### PR DESCRIPTION
Return parameters of GetInboxItem() have changed in 7.0.3

Instead of returning name, itemTexture, count, quality, canUse the function now returns name, itemID, itemTexture, count, quality, canUse

Source: http://wow.gamepedia.com/Patch_7.0.3/API_changes