### PR TITLE
Add pkgmeta file for Curse packaging

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -1,0 +1,7 @@
+package-as: BagSync
+
+externals:
+    libs/CustomSearch-1.0: https://github.com/Jaliborc/CustomSearch-1.0.git
+    libs/LibDataBroker-1.1: https://github.com/tekkub/libdatabroker-1-1.git
+    libs/LibItemSearch-1.2: https://github.com/Jaliborc/LibItemSearch-1.2.git
+    libs/Unfit-1.0: https://github.com/Jaliborc/Unfit-1.0.git


### PR DESCRIPTION
The CurseForge packager does not automatically include external Git submodules in the packages - you need a control file for this called ".pkgmeta"

As a result, the current 10.0 version on Curse is lacking any of these libraries.

Here is a simple one that just pulls in the 4 Git submodule libraries.

For Bonus points, this could also be converted to pull in the Ace3 libraries, so you don't need to have them in the repository, but first step is to make the package work.