### PR TITLE
Fix LibQTip library

### DIFF
--- a/libs/LibQTip-1.0/LibQTip-1.0.lua
+++ b/libs/LibQTip-1.0/LibQTip-1.0.lua
@@ -171,9 +171,9 @@ local frameHeap = lib.frameHeap
 local function AcquireFrame(parent)
 	local frame = tremove(frameHeap) or CreateFrame("Frame", nil, nil, BackdropTemplateMixin and "BackdropTemplate")
 	frame:SetParent(parent)
-	--[===[@debug@
+	--@debug@
 	usedFrames = usedFrames + 1
-	--@end-debug@]===]
+	--@end-debug@
 	return frame
 end
 
@@ -186,9 +186,9 @@ local function ReleaseFrame(frame)
 	ClearFrameScripts(frame)
 
 	tinsert(frameHeap, frame)
-	--[===[@debug@
+	--@debug@
 	usedFrames = usedFrames - 1
-	--@end-debug@]===]
+	--@end-debug@
 end
 
 ------------------------------------------------------------------------------
@@ -398,9 +398,9 @@ function AcquireTooltip()
 		setmetatable(tooltip, tipMetatable)
 	end
 
-	--[===[@debug@
+	--@debug@
 	usedTooltips = usedTooltips + 1
-	--@end-debug@]===]
+	--@end-debug@
 	return tooltip
 end
 
@@ -463,9 +463,9 @@ function ReleaseTooltip(tooltip)
 	highlightTexture:SetTexture(DEFAULT_HIGHLIGHT_TEXTURE_PATH)
 	highlightTexture:SetTexCoord(0, 1, 0, 1)
 
-	--[===[@debug@
+	--@debug@
 	usedTooltips = usedTooltips - 1
-	--@end-debug@]===]
+	--@end-debug@
 end
 
 ------------------------------------------------------------------------------
@@ -513,9 +513,9 @@ local tableHeap = lib.tableHeap
 -- Returns a table
 function AcquireTable()
 	local tbl = tremove(tableHeap) or {}
-	--[===[@debug@
+	--@debug@
 	usedTables = usedTables + 1
-	--@end-debug@]===]
+	--@end-debug@
 	return tbl
 end
 
@@ -523,9 +523,9 @@ end
 function ReleaseTable(tableInstance)
 	wipe(tableInstance)
 	tinsert(tableHeap, tableInstance)
-	--[===[@debug@
+	--@debug@
 	usedTables = usedTables - 1
-	--@end-debug@]===]
+	--@end-debug@
 end
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
The included copy was somehow causing issues with the packager, so use a
clean variant to avoid issues