### PR TITLE
Add inventory category to TOC

### DIFF
--- a/BagSync.toc
+++ b/BagSync.toc
@@ -12,6 +12,17 @@
 ## X-Wago-ID: xZKxjQNk
 ## OptionalDeps: tekDebug
 ## SavedVariables: BagSyncDB
+## Category-enUS: Inventory
+## Category-deDE: Inventar
+## Category-esES: Inventario
+## Category-esMX: Inventario
+## Category-frFR: Inventaire
+## Category-itIT: Inventario
+## Category-koKR: 소지품
+## Category-ptBR: Inventário
+## Category-ruRU: Предметы
+## Category-zhCN: 物品栏
+## Category-zhTW: 物品欄
 
 libs\LibStub\LibStub.lua
 libs\CallbackHandler-1.0\CallbackHandler-1.0.xml


### PR DESCRIPTION
Since Patch 11.1, it is possible to categorize an addon and group them. More info: https://warcraft.wiki.gg/wiki/Patch_11.1.0/API_changes