### PR TITLE
Update profession tooltip line for consistency

### DIFF
--- a/modules/professions.lua
+++ b/modules/professions.lua
@@ -351,8 +351,7 @@ function Professions:Item_OnEnter(btn)
 			-- 配方搜索结果的提示
 			GameTooltip:AddLine("|cFFFFFFFF"..PLAYER..":|r  "..btn.data.colorized)
 			GameTooltip:AddLine("|cFFFFFFFF"..L.Realm.."|r  "..btn.data.unitRealm)
-			GameTooltip:AddLine("|cFFFFFFFF"..L.Profession..":|r  "..btn.data.professionName)
-			GameTooltip:AddLine("|cFFFFFFFF"..L.Category..":|r  "..btn.data.tierName)
+			GameTooltip:AddLine("|cFFFFFFFF"..L.Professions..":|r  "..btn.data.professionName)
 			GameTooltip:AddLine(" ")
 			
 			-- 显示配方信息


### PR DESCRIPTION
Fixed key value L.Profession to L.Professions to be consistent with Locals definition

Clear L.Category in GameTooltip, which has been displayed in the search results.